### PR TITLE
[FB] Code | Allow moving window when tabbar is at the bottom

### DIFF
--- a/browser/base/content/browser-tabbar.js
+++ b/browser/base/content/browser-tabbar.js
@@ -143,6 +143,8 @@ const tabbarDisplayStyleFunctions = {
           "floorp-tabbar-display-style",
           "3"
         );
+        // set margin to the top of urlbar container & allow moving the window
+        document.getElementById("urlbar-container").style.marginTop = "10px"; 
         break;
     }
   },
@@ -159,6 +161,8 @@ const tabbarDisplayStyleFunctions = {
     );
     document.querySelector("#floorp-tabbar-modify-css")?.remove();
     tabbarContents.tabbarElement.removeAttribute("floorp-tabbar-display-style");
+    // Remove tabbar margin from the top (when tabs are at the bottom)
+    document.getElementById("urlbar-container")?.style.removeProperty("margin-top");
     tabbarDisplayStyleFunctions.moveToDefaultSpace();
   },
 


### PR DESCRIPTION
This adds margin on the top of the urlbar and allows Floorp with the tabbar at the bottom to be properly dragged across the screen.

![image](https://github.com/Floorp-Projects/Floorp-core/assets/89523758/992aa2a6-81f0-4931-928a-6dd066875c62)
