### PR TITLE
[FB] Tab Sleep | Use correct EventTarget for tab context menu

### DIFF
--- a/browser/components/tabsleep/TabSleep.sys.mjs
+++ b/browser/components/tabsleep/TabSleep.sys.mjs
@@ -369,7 +369,7 @@ async function createTabContextElement(document_) {
         window_.TabContextMenu.contextTab.isTabSleepExcludeTab =
             !window_.TabContextMenu.contextTab.isTabSleepExcludeTab;
     });
-    tabSleepExcludeTab.addEventListener("popupshowing", async function(e) {
+    tabContextMenu.addEventListener("popupshowing", async function(e) {
         let window_ = e.currentTarget.ownerGlobal;
         e.currentTarget.querySelector("#context_tabSleepExcludeTab").setAttribute(
             "checked",


### PR DESCRIPTION
### Check list
- [X] Have tested the modifications
- [X] Referenced all related issues

---

<!-- Please enter details on below this line -->

**Related Issues:**
https://github.com/Floorp-Projects/Floorp/issues/529

I have the same issue as reported above. I am also using Arch Linux in a Wayland session.

**Fix description:**
It seems that on some platforms, the `popupshowing` event is not triggered for the `tabSleepExcludeTab` `EventTarget`.

I have confirmed that changing the `EventTarget` to `tabContextMenu` fixes the issue.

This follows the same pattern seen on [floorp/browser/components/OpenLinkInExternal.sys.mjs](https://github.com/Floorp-Projects/Floorp-core/blob/0e20b8cb30e01dd456c0720e836ce27a52e7043e/browser/components/OpenLinkInExternal.sys.mjs#L360C24-L360C24), where the `addEventListener` method is called on the tab context menu itself, rather than on the created menu item.
