### PR TITLE
Fix: vertical tab bar animation on mouseleave

### DIFF
--- a/browser/themes/designs/options/native-verticaltab-hover.css
+++ b/browser/themes/designs/options/native-verticaltab-hover.css
@@ -28,7 +28,9 @@
 /*close*/
 #TabsToolbar {
   width: var(--default-verticaltab-width) !important;
+  transition: all 200ms !important;
   transition-delay: 0.2s !important;
+  z-index: 100 !important;
 }
 
 #TabsToolbar:not(:hover) #tabbrowser-tabs[closebuttons="activetab"] .tabbrowser-tab .tab-content[class] > .tab-close-button[class] {
@@ -51,9 +53,6 @@
 
 /*open*/
 #TabsToolbar:hover {
-  transition: all 200ms !important;
-  transition-delay: 0.2s !important;
-  z-index: 100 !important;
   width: 250px !important;
 }
 


### PR DESCRIPTION
Vertical tab bar with `Collapse Vertical Tab Bar` option has smooth animation on hover, but cuts off when leaving hover, which seems not desired by the looks of source code

Before change:

https://github.com/Floorp-Projects/Floorp-core/assets/91969420/cac64e9d-ba5e-452a-9b34-190e8f1fe140

After:

https://github.com/Floorp-Projects/Floorp-core/assets/91969420/e4ec2754-02ac-4d6e-b062-8bb408191e82

