### PR TITLE
[FB] Code | Made windows draggable

### DIFF
--- a/browser/base/content/browser-floorp.css
+++ b/browser/base/content/browser-floorp.css
@@ -536,6 +536,15 @@ toolbar #workspace-button:not([disabled="true"], [checked], [open], :active):hov
   list-style-image: url("chrome://browser/skin/floorp-share.svg");
 }
 
+.toolbar-items,
+#nav-bar-customization-target  {
+  margin-top: 1px;
+}
+
+.titlebar-spacer {
+  width: 10px !important;
+}
+
 @media (min-resolution: 1.1dppx){
  toolbar[brighttext] .webextension-browser-action {
    list-style-image: var(--webextension-toolbar-image-2x-light, inherit) !important;

--- a/browser/base/content/browser-tabbar.js
+++ b/browser/base/content/browser-tabbar.js
@@ -143,8 +143,6 @@ const tabbarDisplayStyleFunctions = {
           "floorp-tabbar-display-style",
           "3"
         );
-        // set margin to the top of urlbar container & allow moving the window
-        document.getElementById("urlbar-container").style.marginTop = "10px"; 
         break;
     }
   },
@@ -161,8 +159,6 @@ const tabbarDisplayStyleFunctions = {
     );
     document.querySelector("#floorp-tabbar-modify-css")?.remove();
     tabbarContents.tabbarElement.removeAttribute("floorp-tabbar-display-style");
-    // Remove tabbar margin from the top (when tabs are at the bottom)
-    document.getElementById("urlbar-container")?.style.removeProperty("margin-top");
     tabbarDisplayStyleFunctions.moveToDefaultSpace();
   },
 


### PR DESCRIPTION
- Reverted commit 8721a3a because it makes the UI look weird.
- added `1px` margin at the top of `.toolbar-items` to make the windows draggable when maximized
- added `1px` margin at the top of `#nav-bar-customization-target` to make maximized windows draggable when TabBar is hidden or at a different location
- Remove too much space in the titlebar pre-tabs (when not maximized) and after the Floorp view button.