### PR TITLE
[FB] | Design: improve template selection design

### DIFF
--- a/browser/components/welcome/welcome.css
+++ b/browser/components/welcome/welcome.css
@@ -79,7 +79,7 @@ body {
     width: fit-content;
     border: 1px solid rgba(170, 170, 170, 0.6);
     border-radius: 10px;
-    min-width: 550px;
+    min-width: 750px;
     max-width: 550px;
     padding: 100px;
 }
@@ -130,16 +130,22 @@ body {
 }
 
 .second-option-icons {
-    height: 25px;
+    height: 60px;
+    margin-bottom: 3px;
 }
 
 #second-template-options-flex-box {
     display: flex;
+    justify-content: center;
+    align-items: center; 
 }
 
 .second-template-option {
     margin: 30px;
-    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
 }
 
 .second-template-option-text {
@@ -147,7 +153,7 @@ body {
 }
 
 .second-template-option-description {
-    width: 125px;
+    margin-bottom: 20px;
 }
 
 #second-select-button {


### PR DESCRIPTION
Now template selection looks like this: 
![image](https://github.com/Floorp-Projects/Floorp-core/assets/89523758/da498347-6ae5-486a-9801-99b04c3bda36)

Instead of this:
![image](https://github.com/Floorp-Projects/Floorp-core/assets/89523758/4fd1f8d4-2343-43cb-90be-48df47db6fc6)
