### PR TITLE
[FB] Bookmarks Toolbar | Bug Fix

### DIFF
--- a/browser/base/content/browser-UI-custom.js
+++ b/browser/base/content/browser-UI-custom.js
@@ -81,40 +81,31 @@ observePreference("floorp.bookmarks.fakestatus.mode", function (event) {
   let eventListener = null;
 
   if (event.prefValue) {
-    setTimeout(
+    document
+      .getElementById("fullscreen-and-pointerlock-wrapper")
+      .after(document.getElementById("PersonalToolbar"));
+    eventListener = document.addEventListener(
+      "floorpOnLocationChangeEvent",
       function () {
-        document
-          .getElementById("fullscreen-and-pointerlock-wrapper")
-          .after(document.getElementById("PersonalToolbar"));
-        eventListener = document.addEventListener(
-          "floorpOnLocationChangeEvent",
-          function () {
-            let { AboutNewTab } = ChromeUtils.import(
-              "resource:///modules/AboutNewTab.jsm",
-            );
-            let currentUrl = gFloorpOnLocationChange.locationURI.spec;
-            let newtabUrl = AboutNewTab.newTabURL;
-            let pref = Services.prefs.getStringPref(
-              "browser.toolbars.bookmarks.visibility",
-              "always",
-            );
-
-            if (
-              (currentUrl == newtabUrl && pref == "newtab") ||
-              pref == "always"
-            ) {
-              document
-                .getElementById("PersonalToolbar")
-                .removeAttribute("collapsed");
-            } else {
-              document
-                .getElementById("PersonalToolbar")
-                .setAttribute("collapsed", "true");
-            }
-          },
+        let currentUrl = gFloorpOnLocationChange.locationURI.spec;
+        let pref = Services.prefs.getStringPref(
+          "browser.toolbars.bookmarks.visibility",
+          "always",
         );
+
+        if (
+          ((currentUrl == "about:newtab" || currentUrl == "about:home") && pref == "newtab") ||
+          pref == "always"
+        ) {
+          document
+            .getElementById("PersonalToolbar")
+            .removeAttribute("collapsed");
+        } else {
+          document
+            .getElementById("PersonalToolbar")
+            .setAttribute("collapsed", "true");
+        }
       },
-      event.reason === "init" ? 250 : 1,
     );
   } else if (event.reason === "changed") {
     //Fix for the bug that bookmarksbar is on the navigation toolbar when the pref is cahaned to false


### PR DESCRIPTION
Fix issue where Bookmarks Toolbar wasn't showing up at startup when "Show bookmarks toolbar at the bottom of floorp" is enabled and bookmark visibility is set to "newtab".

Before:

https://github.com/Floorp-Projects/Floorp-core/assets/87632612/3fac5abb-772e-4193-b8a8-30c4264ed629

After:

https://github.com/Floorp-Projects/Floorp-core/assets/87632612/a161fd59-a6da-4d38-828a-bf9e4d309ad4

Solution: Add `about:home` to the list of URLs to be checked.