### PR TITLE
[FB] Sidebar | Remove freasearch as placeholder

### DIFF
--- a/browser/components/preferences/dialogs/customURLs.xhtml
+++ b/browser/components/preferences/dialogs/customURLs.xhtml
@@ -46,7 +46,7 @@
       </hbox>
     <label id="urlLabel" control="url" data-l10n-id="permissions-address" class="invisible"/>
     <vbox class="invisible">
-      <html:input id="customURL" class="URLBox" type="text" value="" placeholder="https://freasearch.org/"/>
+      <html:input id="customURL" class="URLBox" type="text" value="" placeholder="https://duckduckgo.com/"/>
     </vbox>
     <label id="usercontextLabel" data-l10n-id="bsb-context" class="invisible"/>
       <hbox class="invisible">


### PR DESCRIPTION
This PR removes freasearch as a placeholder and replaces is with ddg