### PR TITLE
[FB] BMS | Disallow empty urls

### DIFF
--- a/browser/components/preferences/dialogs/customURLs.js
+++ b/browser/components/preferences/dialogs/customURLs.js
@@ -189,6 +189,10 @@ function setPref() {
   let userAgent = document.querySelector("#userAgentCheck").checked;
   let width = Number(document.querySelector("#widthBox").value);
 
+  if (url.length === 0) {
+    return;
+  }
+
   let dataObject = {};
   if (page != 0) {
     dataObject.url = document.querySelector("#pageSelect").value;


### PR DESCRIPTION
This PR disallows creating custom entries with empty URLs on BMS