### PR TITLE
[FB] Preferences | Remove redundant Back to General button

### DIFF
--- a/browser/components/preferences/ssb.inc.xhtml
+++ b/browser/components/preferences/ssb.inc.xhtml
@@ -6,16 +6,6 @@
 
 <html:template id="template-paneSsb">
 
-## Go main preference pane button.
-    <hbox class="container-header-links" data-category="paneSsb" hidden="true">
-        <button id="backtogeneral-ssb" class="back-button" data-l10n-id="containers-back-button2">
-            <hbox class="box-inherit button-box" align="center" pack="center" flex="1" anonid="button-box">
-                <image class="button-icon" />
-                <label class="button-text" />
-            </hbox>
-        </button>
-    </hbox>
-
     <groupbox data-category="paneSsb" hidden="true">
         <vbox class="contentPane">
             <html:h1 data-l10n-id="floorp-ssb-title" />

--- a/browser/components/preferences/ssb.js
+++ b/browser/components/preferences/ssb.js
@@ -70,11 +70,6 @@ const gSsbPane = {
 
   async init() {
     this._pane = document.getElementById("paneSsb");
-    document
-      .getElementById("backtogeneral-ssb")
-      .addEventListener("command", () => {
-        gotoPref("general");
-      });
 
     const needreboot = document.getElementsByClassName("needreboot");
     for (let i = 0; i < needreboot.length; i++) {

--- a/browser/components/preferences/workspaces.inc.xhtml
+++ b/browser/components/preferences/workspaces.inc.xhtml
@@ -6,17 +6,6 @@
 
 <html:template id="template-paneWorkspaces">
 
-## Go main preference pane button.
-  <hbox class="container-header-links" data-category="paneWorkspaces" hidden="true">
-    <button id="backtogeneral-workspaces" class="back-button" data-l10n-id="containers-back-button2">
-      <hbox class="box-inherit button-box" align="center" pack="center" flex="1" anonid="button-box">
-        <image class="button-icon" />
-        <label class="button-text" />
-      </hbox>
-    </button>
-  </hbox>
-
-
 ## Some elements share id & with notes.inc.xhtml
   <groupbox data-category="paneWorkspaces" hidden="true">
     <vbox class="contentPane">

--- a/browser/components/preferences/workspaces.js
+++ b/browser/components/preferences/workspaces.js
@@ -33,11 +33,6 @@ const gWorkspacesPane = {
   _pane: null,
   init() {
     this._pane = document.getElementById("paneWorkspaces");
-    document
-      .getElementById("backtogeneral-workspaces")
-      .addEventListener("command", () => {
-        gotoPref("general");
-      });
 
     const needreboot = document.getElementsByClassName("needreboot");
     for (let i = 0; i < needreboot.length; i++) {


### PR DESCRIPTION
設定のワークスペースとSSBのページにある一般に戻るボタンを削除しました

Before:
<img width="320" alt="image" src="https://github.com/Floorp-Projects/Floorp-core/assets/87810571/55e42640-6824-4e0e-b2e2-89f663932426">

After:
<img width="359" alt="image" src="https://github.com/Floorp-Projects/Floorp-core/assets/87810571/3ddcb4f1-ce55-407c-84d1-b00209fef2f6">
