### PR TITLE
[FB] Tabbar | Add whitespace when tabbar on bottom

### DIFF
--- a/browser/base/content/browser-tabbar.js
+++ b/browser/base/content/browser-tabbar.js
@@ -164,8 +164,8 @@ const tabbarDisplayStyleFunctions = {
     tabbarContents.tabbarElement.removeAttribute("floorp-tabbar-display-style");
     // Remove tabbar margin from the top (when tabs are at the bottom)
     document
-      .getElementById("urlbar-container")
-      ?.style.removeProperty("margin-top");
+      .getElementById("nav-bar")
+      ?.style.removeProperty("padding-top");
     tabbarDisplayStyleFunctions.moveToDefaultSpace();
   },
 

--- a/browser/base/content/browser-tabbar.js
+++ b/browser/base/content/browser-tabbar.js
@@ -145,7 +145,7 @@ const tabbarDisplayStyleFunctions = {
           "3",
         );
         // set margin to the top of urlbar container & allow moving the window
-        document.getElementById("urlbar-container").style.marginTop = "10px";
+        document.getElementById("nav-bar").style.paddingTop = "10px";
         break;
     }
   },


### PR DESCRIPTION
This PR changes the way user was able to drag browser, when tabbar was at the bottom (adds the proper whitespace).
It also fixes weird display of search bar.