### PR TITLE
Fix `Exec` field code for urls

### DIFF
--- a/browser/components/OpenLinkInExternal.sys.mjs
+++ b/browser/components/OpenLinkInExternal.sys.mjs
@@ -339,7 +339,7 @@ async function OpenLinkInExternal(url) {
     }
     let shellscript = "#!/bin/sh\n";
     shellscript += browser.fileInfo["Desktop Entry"].Exec.replace(
-      "%u",
+      "/%[uU]/",
       EscapeShell(url),
     );
     let randomized = Math.random().toString(32).substring(2);


### PR DESCRIPTION
This fixes "Open Link in Default Browser" in Linux for Chromium based browsers like Brave.

They use `%U` instead of `%u` in their `Exec` field. This follows the Freedesktop's Desktop Entry Specification. https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html

> |Code |Description |
> | --- |--- |
> | %u |	A single URL. Local files may either be passed as file: URLs or as file path. |
> | %U |	A list of URLs. Each URL is passed as a separate argument to the executable program. Local files may either be passed as file: URLs or as file path. |
