### PR TITLE
[FB] VerticalTab | Allow hiding padding on top

### DIFF
--- a/browser/app/profile/000-floorp.js
+++ b/browser/app/profile/000-floorp.js
@@ -115,6 +115,7 @@ pref("floorp.verticaltab.hover.enabled", false);
 pref("floorp.browser.tabs.verticaltab.right", false);
 pref("floorp.browser.tabs.verticaltab.temporary.disabled", false);
 pref("floorp.browser.tabs.verticaltab.width", 200);
+pref("floorp.verticaltab.paddingtop.enabled", false);
 
 // Chrome 形式のダウンローダー
 pref("floorp.browser.native.downloadbar.enabled", false);

--- a/browser/base/content/browser-tabbar.js
+++ b/browser/base/content/browser-tabbar.js
@@ -82,6 +82,9 @@ const tabbarDisplayStyleFunctions = {
             margin-inline-start: 7px !important;
           }
         `;
+
+        enablePadding()
+
         document.querySelector("head").appendChild(tabbarContents.modifyCSS);
         tabbarDisplayStyleFunctions.setWorkspaceLabelToNavbar();
         tabbarContents.tabbarElement.setAttribute(
@@ -224,6 +227,11 @@ SessionStore.promiseInitialized.then(() => {
 
 //-------------------------------------------------------------------------Multirow-tabs----------------------------------------------------------------------------
 
+function enablePadding(){
+  const isPaddingTopEnabled = Services.prefs.getBoolPref("floorp.verticaltab.paddingtop.enabled", false)
+  document.getElementById("titlebar").style.padding = isPaddingTopEnabled ? "10px" : "0px"
+}
+
 function setMultirowTabMaxHeight() {
   const arrowscrollbox = document.querySelector("#tabbrowser-arrowscrollbox");
   const scrollbox = arrowscrollbox.shadowRoot.querySelector("[part=scrollbox]");
@@ -301,6 +309,10 @@ document.addEventListener(
       "floorp.browser.tabbar.multirow.max.enabled",
       setMultirowTabMaxHeight,
     );
+    Services.prefs.addObserver(
+      "floorp.verticaltab.paddingtop.enabled",
+      enablePadding,
+    )
     Services.prefs.addObserver(
       "floorp.browser.tabbar.multirow.newtab-inside.enabled",
       setNewTabInTabs,

--- a/browser/components/preferences/design.inc.xhtml
+++ b/browser/components/preferences/design.inc.xhtml
@@ -73,6 +73,7 @@
       <checkbox preference="floorp.browser.tabs.verticaltab.right" id="nativeVerticalTab" data-l10n-id="native-vertical-tab-show-right" />
       <checkbox preference="floorp.verticaltab.hover.enabled" id="hoverVerticalTab" data-l10n-id="hover-vertical-tab" class="verticalTabs needreboot" />
       <checkbox preference="floorp.verticaltab.show.newtab.button" id="verticalTabNewTabButton" data-l10n-id="floorp-show-vertical-tab-newtab-button" class="verticalTabs" />
+      <checkbox preference="floorp.verticaltab.paddingtop.enabled" id="verticalTabPadding" data-l10n-id="native-vertical-tab-show-padding" class="verticalTabs" />
     </radiogroup>
 
     <vbox class="TST ContentBlockBox">

--- a/browser/components/preferences/design.js
+++ b/browser/components/preferences/design.js
@@ -20,6 +20,7 @@ Preferences.addAll([
   { id: "floorp.titlebar.favicon.color", type: "bool" },
   { id: "floorp.Tree-type.verticaltab.optimization", type: "bool" },
   { id: "floorp.browser.tabs.verticaltab.right", type: "bool" },
+  { id: "floorp.verticaltab.paddingtop.enabled", type: "bool" },
   { id: "floorp.verticaltab.hover.enabled", type: "bool" },
   { id: "floorp.verticaltab.show.newtab.button", type: "bool" },
 ]);


### PR DESCRIPTION
Add toggler to hide padding at the top.
Goes in with: https://github.com/Floorp-Projects/Unified-l10n-central/pull/49