### PR TITLE
[FB] Vertical Tabs | Fixed website resizing and margin in webpanels

### DIFF
--- a/browser/themes/designs/options/native-verticaltab-hover.css
+++ b/browser/themes/designs/options/native-verticaltab-hover.css
@@ -64,11 +64,15 @@
   }
 
   #TabsToolbar {
-    margin-right: -27px;
+    margin-right: -53px;
   }
 
   #appcontent {
-    margin-left: 27px;
+    margin-left: 53px;
+  }
+
+  .webpanels {
+    margin-left: -28px;
   }
 }
 

--- a/browser/themes/designs/options/native-verticaltab-hover.css
+++ b/browser/themes/designs/options/native-verticaltab-hover.css
@@ -74,6 +74,10 @@
   .webpanels {
     margin-left: -28px;
   }
+  
+  #sidebar-splitter2 {
+    position: relative;
+  }
 }
 
 #TabsToolbar:not(:hover) #tabbrowser-tabs[closebuttons="activetab"] .tabbrowser-tab .tab-content[class] > .tab-close-button[class] {


### PR DESCRIPTION
Fixed website resizing when hovering over collapsed tabs and margin inside webpanels when collapsed tabs are active.
https://github.com/Floorp-Projects/Floorp/issues/1050 (I couldn't find the original issue)
https://github.com/Floorp-Projects/Floorp/issues/1096