### PR TITLE
[FB] SSB | Use `Services` to find binary location

### DIFF
--- a/browser/base/content/modules/ssb/LinuxSupport.mjs
+++ b/browser/base/content/modules/ssb/LinuxSupport.mjs
@@ -44,7 +44,7 @@ export const LinuxSupport = {
       iconFile = null;
     }
 
-    let command = "/usr/bin/floorp";
+    let command = Services.dirsvc.get("XREExeF",Ci.nsIFile).path;
     if (FileUtils.File("/.flatpak-info").exists()) {
       command = "flatpak run one.ablaze.floorp";
     }


### PR DESCRIPTION
Instead of assuming the location of the binary, use Firefox Services to find the right location.