### PR TITLE
[FB] set style to about:contributors page | added style used in other…

### DIFF
--- a/browser/components/about/aboutcontributors/contributors.html
+++ b/browser/components/about/aboutcontributors/contributors.html
@@ -3,6 +3,7 @@
   <head>
     <title>Floorp Browser Contributors</title>
     <meta charset="UTF-8" />
+    <link rel="stylesheet" href="chrome://global/skin/in-content/info-pages.css">
   </head>
 
   <body>


### PR DESCRIPTION
`about:contributors` に、他のaboutページと共通のスタイルを追加しました。
aboutページではdark readerも使えないので、ダークテーマに対応してほしいと思ってのプルリクです。

headタグに`<link rel="stylesheet" href="chrome://global/skin/in-content/info-pages.css">`を追加しただけになります。